### PR TITLE
Pin to cap release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" 
 futures = "0.3.16"
 generic-array = { version = "0.14.4", features = ["serde"] }
 itertools = "0.10.1"
-jf-cap = { features=["std"], git = "https://github.com/EspressoSystems/cap.git" }
-jf-utils = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git" }
+jf-cap = { features=["std"], git = "https://github.com/EspressoSystems/cap.git", tag = "0.0.2" }
+jf-utils = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.61"
 snafu = { version = "0.7", features = ["backtraces"] }
 surf = "2.3.1"
-tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", branch = "main"}
+tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.1.0" }
 tide = "0.16.0"
 tracing = "0.1.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.16"
 generic-array = { version = "0.14.4", features = ["serde"] }
 itertools = "0.10.1"
 jf-cap = { features=["std"], git = "https://github.com/EspressoSystems/cap.git", tag = "0.0.2" }
-jf-utils = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git",com tag = "0.1.0" }
+jf-utils = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.61"
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "net"
 description = "Generic interfaces for Espresso web APIs."
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
@@ -15,7 +15,7 @@ futures = "0.3.16"
 generic-array = { version = "0.14.4", features = ["serde"] }
 itertools = "0.10.1"
 jf-cap = { features=["std"], git = "https://github.com/EspressoSystems/cap.git", tag = "0.0.2" }
-jf-utils = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.0" }
+jf-utils = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git",com tag = "0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.61"
 snafu = { version = "0.7", features = ["backtraces"] }


### PR DESCRIPTION
For seahorse to release all of its dependencies must point to the same versions of JF and cap.