### PR TITLE
Improve error handling.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ bincode = "1.3.3"
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }
 futures = "0.3.16"
 generic-array = { version = "0.14.4", features = ["serde"] }
+hex = "0.4"
 itertools = "0.10.1"
 jf-cap = { features=["std"], git = "https://github.com/EspressoSystems/cap.git", branch = "testnet-v1" }
 jf-utils = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.1" }
@@ -23,3 +24,6 @@ surf = "2.3.1"
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.2.0" }
 tide = "0.16.0"
 tracing = "0.1.26"
+
+[dev-dependencies]
+async-std = { version = "1.11", features = ["attributes"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -44,12 +44,70 @@ pub async fn response_body<T: for<'de> Deserialize<'de>>(
     }
 }
 
+async fn response_error<E: Error>(res: &mut Response) -> E {
+    // To add context to the error, try to interpret the response body as a serialized error. Since
+    // `body_json`, `body_string`, etc. consume the response body, we will extract the body as raw
+    // bytes and then try various potential decodings based on the response headers and the contents
+    // of the body.
+    let bytes = match res.body_bytes().await {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            // If we are unable to even read the body, just return a generic error message based on
+            // the status code.
+            return E::catch_all(format!(
+                "Request terminated with error {}. Failed to read request body due to {}",
+                res.status(),
+                err
+            ));
+        }
+    };
+    if let Some(content_type) = res.header("Content-Type") {
+        // If the response specifies a content type, check if it is one of the types we know how to
+        // deserialize, and if it is, we can then see if it deserializes to an `E`.
+        match content_type.as_str() {
+            "application/json" => {
+                if let Ok(err) = serde_json::from_slice(&bytes) {
+                    return err;
+                }
+            }
+            "application/octet-stream" => {
+                if let Ok(err) = bincode::deserialize(&bytes) {
+                    return err;
+                }
+            }
+            _ => {}
+        }
+    }
+    // If we get here, then we were not able to interpret the response body as an `E` directly. This
+    // can be because:
+    //  * the content type is not supported for deserialization
+    //  * the content type was unspecified
+    //  * the body did not deserialize to an `E`
+    // We have one thing left we can try: if the body is a string, we can use the `catch_all`
+    // variant of `E` to include the contents of the string in the error message.
+    if let Ok(msg) = std::str::from_utf8(&bytes) {
+        return E::catch_all(msg.to_string());
+    }
+
+    // The response body was not an `E` or a string. Return the most helpful error message we can,
+    // including the status code, content type, and raw body.
+    E::catch_all(format!(
+        "Request terminated with error {}. Content-Type: {}. Body: 0x{}",
+        res.status(),
+        match res.header("Content-Type") {
+            Some(content_type) => content_type.as_str(),
+            None => "unspecified",
+        },
+        hex::encode(&bytes)
+    ))
+}
+
 pub async fn response_to_result<E: Error>(mut res: Response) -> surf::Result<Response> {
     if res.status() == StatusCode::Ok {
         Ok(res)
     } else {
-        let err: E = response_body(&mut res).await?;
-        Err(surf::Error::new(err.status(), err))
+        let err = response_error::<E>(&mut res).await;
+        Err(surf::Error::new(res.status(), err))
     }
 }
 
@@ -75,4 +133,140 @@ pub fn parse_error_body<E: Error>(
         next.run(req, client)
             .and_then(|res| async { response_to_result::<E>(res).await }),
     )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use snafu::Snafu;
+    use surf::http::{self, mime, Body};
+
+    #[derive(Clone, Debug, Deserialize, Serialize, Snafu, PartialEq, Eq)]
+    struct Error {
+        msg: String,
+    }
+
+    impl crate::Error for Error {
+        fn catch_all(msg: String) -> Self {
+            Self { msg }
+        }
+
+        fn status(&self) -> StatusCode {
+            StatusCode::InternalServerError
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+    struct Data {
+        field: u32,
+    }
+
+    #[async_std::test]
+    async fn test_response_body_json() {
+        let data = Data::default();
+        let mut res = http::Response::new(StatusCode::Ok);
+        res.set_content_type(mime::JSON);
+        res.set_body(Body::from_json(&data).unwrap());
+
+        // Convert the resopnse to a result, check that it is Ok, and deserialize the body.
+        let mut res = response_to_result::<Error>(res.into()).await.unwrap();
+        assert_eq!(data, response_body(&mut res).await.unwrap());
+    }
+
+    #[async_std::test]
+    async fn test_response_body_bincode() {
+        let data = Data::default();
+        let mut res = http::Response::new(StatusCode::Ok);
+        res.set_content_type(mime::BYTE_STREAM);
+        res.set_body(bincode::serialize(&data).unwrap());
+
+        // Convert the resopnse to a result, check that it is Ok, and deserialize the body.
+        let mut res = response_to_result::<Error>(res.into()).await.unwrap();
+        assert_eq!(data, response_body(&mut res).await.unwrap());
+    }
+
+    #[async_std::test]
+    async fn test_response_error_json() {
+        let msg = "This is an error message".to_string();
+        let err = Error { msg };
+        let mut res = http::Response::new(StatusCode::InternalServerError);
+        res.set_content_type(mime::JSON);
+        res.set_body(Body::from_json(&err).unwrap());
+
+        // Convert the response to a result, check that it is Err, and deserialize the body.
+        let res = response_to_result::<Error>(res.into()).await.unwrap_err();
+        assert_eq!(err, res.downcast().unwrap());
+    }
+
+    #[async_std::test]
+    async fn test_response_error_bincode() {
+        let msg = "This is an error message".to_string();
+        let err = Error { msg };
+        let mut res = http::Response::new(StatusCode::InternalServerError);
+        res.set_content_type(mime::BYTE_STREAM);
+        res.set_body(bincode::serialize(&err).unwrap());
+
+        // Convert the response to a result, check that it is Err, and deserialize the body.
+        let res = response_to_result::<Error>(res.into()).await.unwrap_err();
+        assert_eq!(err, res.downcast().unwrap());
+    }
+
+    #[async_std::test]
+    async fn test_response_error_plaintext() {
+        let msg = "This is an error message".to_string();
+        let mut res = http::Response::new(StatusCode::InternalServerError);
+        res.set_body(msg.clone());
+
+        // Convert the response to a result, check that it is Err, and check that the error message
+        // matches `msg`.
+        let res = response_to_result::<Error>(res.into()).await.unwrap_err();
+        let err: Error = res.downcast().unwrap();
+        assert_eq!(err.msg, msg);
+    }
+
+    #[async_std::test]
+    async fn test_response_error_html() {
+        let msg = "<p>This is an error message</p>".to_string();
+        let mut res = http::Response::new(StatusCode::InternalServerError);
+        res.set_content_type(mime::HTML);
+        res.set_body(msg.clone());
+
+        // Convert the response to a result, check that it is Err, and check that the error message
+        // matches `msg`.
+        let res = response_to_result::<Error>(res.into()).await.unwrap_err();
+        let err: Error = res.downcast().unwrap();
+        assert_eq!(err.msg, msg);
+    }
+
+    #[async_std::test]
+    async fn test_response_error_invalid_json() {
+        let json = r#"{"error": "this is an error message"}"#;
+        let mut res = http::Response::new(StatusCode::InternalServerError);
+        res.set_content_type(mime::JSON);
+        res.set_body(json);
+
+        // Convert the response to a result, check that it is Err, and check that the response body
+        // was interpreted as a string error message, since it does not deserialize to an `Error`.
+        let res = response_to_result::<Error>(res.into()).await.unwrap_err();
+        let err: Error = res.downcast().unwrap();
+        assert_eq!(err.msg, json);
+    }
+
+    #[async_std::test]
+    async fn test_response_error_bytes() {
+        // Some bytes that are not valid UTF-8.
+        let bytes = [0xC0u8, 0x7Fu8];
+        assert!(std::str::from_utf8(&bytes).is_err());
+
+        let mut res = http::Response::new(StatusCode::InternalServerError);
+        res.set_content_type(mime::BYTE_STREAM);
+        res.set_body(bytes.as_slice());
+
+        // Convert the response to a result, check that it is Err, and check that the binary body is
+        // encoded in the error message.
+        let res = response_to_result::<Error>(res.into()).await.unwrap_err();
+        let err: Error = res.downcast().unwrap();
+        assert_eq!(err.msg, "Request terminated with error 500. Content-Type: application/octet-stream. Body: 0xc07f");
+    }
 }


### PR DESCRIPTION
Previously, the client middleware which deserializes the body of
error responses to create a descriptive error object would fail if
it didn't understand the content type, or if the body failed to
deserialize to the appropriate error type. The resulting error was
the error raised during the attempt at interpreting the body, such
as "Unsupported content type", and not the error returned by the
request.

This worked poorly even with our own APIs, which return a helpful
HTML document when a route is incorrectly named or misspelled. Since
HTML cannot be deserialized to an error type, the net middleware would
unhelpfully replace this descriptive error information with "Unsupported
content type".

With this change, the middleware will try to convert the response body
to an error, but if it fails it will fall back to just including the
response body in a newly created error message using `catch_all`,
which means HTML errors and the like will not be lost in this middleware.